### PR TITLE
[feature] Global Exception 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,11 @@ bootJar.enabled = false
 allprojects {
     group = 'com.da2jobu'
     version = '0.0.1-SNAPSHOT'
+
+    repositories {
+        mavenCentral()
+    }
+
 }
 
 // 루트 모듈을 제외한 하위 프로젝트 공통 설정
@@ -31,15 +36,14 @@ subprojects {
         }
     }
 
-    repositories {
-        mavenCentral()
-    }
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter'
 
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
+
+        implementation 'org.springframework.boot:spring-boot-starter-web'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/common-libs/common/build.gradle
+++ b/common-libs/common/build.gradle
@@ -10,8 +10,10 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/common-libs/common/src/main/java/common/dto/CommonResponse.java
+++ b/common-libs/common/src/main/java/common/dto/CommonResponse.java
@@ -1,0 +1,82 @@
+package common.dto;
+
+import common.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommonResponse<T> {
+    private int status;
+    private String code;
+    private String message;
+    private T data;
+
+    /**
+     * 내부 생성자 - static factory method 사용 강제
+     */
+    private CommonResponse(int status, String code, String message, T data) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+// ── 성공 응답 (HTTP 200 OK) ──────────────────────────────────
+
+    public static <T> ResponseEntity<CommonResponse<T>> ok(T data) {
+        return ResponseEntity.ok(new CommonResponse<>(200, "SUCCESS", "요청에 성공하였습니다.", data));
+    }
+
+    public static <T> ResponseEntity<CommonResponse<T>> ok(String message, T data) {
+        return ResponseEntity.ok(new CommonResponse<>(200, "SUCCESS", message, data));
+    }
+
+    // 데이터 없이 성공 메시지만 보낼 때 (ex. 로그아웃 성공)
+    public static ResponseEntity<CommonResponse<?>> ok(String message) {
+        return ResponseEntity.ok(new CommonResponse<>(200, "SUCCESS", message, null));
+    }
+
+    // ── 생성 응답 (HTTP 201 Created) ──────────────────────────────
+
+    public static <T> ResponseEntity<CommonResponse<T>> created(String message, T data) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new CommonResponse<>(201, "SUCCESS", message, data));
+    }
+
+    // ── 삭제/수정 후 응답 (HTTP 204 No Content) ───────────────────
+    // Body가 아예 없는 것이 표준이나, 공통 규격 유지를 위해 200 혹은 204 선택 사용
+    public static ResponseEntity<CommonResponse<?>> noContent() {
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
+
+    // ── 실패 응답 (GlobalExceptionHandler용) ────────────────────
+
+    public static ResponseEntity<CommonResponse<?>> error(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new CommonResponse<>(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage(), null));
+    }
+
+    public static ResponseEntity<CommonResponse<?>> error(ErrorCode errorCode, String message) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new CommonResponse<>(errorCode.getStatus().value(), errorCode.getCode(), message, null));
+    }
+
+    // ── Filter용 (ResponseEntity 없이 객체만 반환) ────────────────────
+    public static CommonResponse<?> errorBody(ErrorCode errorCode) {
+        return new CommonResponse<>(
+                errorCode.getStatus().value(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null
+        );
+    }
+}

--- a/common-libs/common/src/main/java/common/exception/CustomException.java
+++ b/common-libs/common/src/main/java/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/common-libs/common/src/main/java/common/exception/ErrorCode.java
+++ b/common-libs/common/src/main/java/common/exception/ErrorCode.java
@@ -1,0 +1,44 @@
+package common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ── Auth / Token ──────────────────────────────────
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그인이 필요합니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다. 다시 로그인해 주세요."),
+    TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "TOKEN_BLACKLISTED", "이미 로그아웃된 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
+    TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "TOKEN_MISMATCH", "토큰 정보가 일치하지 않습니다. 다시 로그인해주세요."),
+
+    // ── User ──────────────────────────────────────────
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "존재하지 않는 사용자입니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "DUPLICATE_USERNAME", "이미 사용 중인 아이디입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "PASSWORD_MISMATCH", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    ALREADY_DELETED(HttpStatus.CONFLICT, "ALREADY_DELETED", "이미 탈퇴한 사용자입니다."),
+    WITHDRAWN_USER(HttpStatus.BAD_REQUEST, "WITHDRAWN_USER", "탈퇴한 계정입니다."),
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, "INVALID_ROLE", "유효하지 않은 권한 값입니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "LOGIN_FAILED", "아이디 또는 비밀번호가 올바르지 않습니다."),
+    CANNOT_DELETE_SELF(HttpStatus.FORBIDDEN,"CANNOT_DELETE_SELF","본인 계정은 삭제할 수 없습니다."),
+    CANNOT_UPDATE_ROLE_SELF(HttpStatus.FORBIDDEN,"CANNOT_UPDATE_ROLE_SELF","본인 권한은 변경할 수 없습니다."),
+
+    // ── Common ────────────────────────────────────────
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "입력값이 유효하지 않습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."),
+    INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "INVALID_PAGE_SIZE", "페이지 크기는 10, 30, 50만 가능합니다."),
+    INVALID_SORT_BY(HttpStatus.BAD_REQUEST, "INVALID_SORT_BY", "정렬 기준이 올바르지 않습니다.");
+
+    // 각 모듈 별로 담당자가 추가
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/common-libs/common/src/main/java/common/exception/GlobalExceptionHandler.java
+++ b/common-libs/common/src/main/java/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,69 @@
+package common.exception;
+
+import common.dto.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 직접 던지는 예외
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CommonResponse<?>> handleCustomException(CustomException e) {
+        log.warn("[CustomException] code={}, message={}", e.getErrorCode().getCode(), e.getMessage());
+        // 내부 status와 HTTP status를 한 번에 해결
+        return CommonResponse.error(e.getErrorCode());
+    }
+
+    // @Valid 유효성 검사 실패한 경우 던지는 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+
+        log.warn("[ValidationException] message={}", message);
+
+        // ResponseEntity.status().body()를 생략하고 바로 반환
+        return CommonResponse.error(ErrorCode.INVALID_INPUT, message);
+    }
+
+    // @PreAuthorize 권한 거부시 던지는 예외
+//    @ExceptionHandler(AuthorizationDeniedException.class)
+//    public ResponseEntity<CommonResponse<?>> handleAuthorizationDeniedException(AuthorizationDeniedException e) {
+//        log.warn("[AuthorizationDeniedException] message={}", e.getMessage());
+//        return CommonResponse.error(ErrorCode.FORBIDDEN);
+//    }
+
+    // Request JSON 필드 비어있는 경우 던지는 예외
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CommonResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("[HttpMessageNotReadableException] message={}", e.getMessage());
+        return CommonResponse.error(ErrorCode.INVALID_INPUT);
+    }
+
+    // 기타 접근 거부 (Filter레벨)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<CommonResponse<?>> handleAccessDeniedException(AccessDeniedException e) {
+        log.warn("[AccessDeniedException] message={}", e.getMessage());
+        return CommonResponse.error(ErrorCode.FORBIDDEN);
+    }
+
+    // 나머지 예상 못한 예외상황
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<?>> unhandledException(Exception e) {
+        log.error("[UnhandledException]", e);
+        // 여기서도 CommonResponse.error()만 사용
+        return CommonResponse.error(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## 🌱 설명
common module에 공통 응답 및 예외 처리 구조를 추가했습니다.

주요 작업 내용
- `CommonResponse` 추가
- `ErrorCode` enum 추가
- `CustomException` 추가
- `GlobalExceptionHandler` 추가

## 📌 관련 이슈
- close #2 

## 💻 커밋 유형
- [x] feat : 새로운 기능 추가
- [ ] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [ ] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
- 현재 공통 예외 코드는 `common module`에 위치시키고, 여러 서비스에서 재사용할 수 있도록 구성했습니다.
- 이후 Security 필터 단계의 예외 처리(`AuthenticationEntryPoint`, `AccessDeniedHandler`)와 연결하면 인증/인가 예외 응답도 같은 포맷으로 통일할 수 있습니다.
- 도메인별 에러 코드가 많아질 경우, 추후 `UserErrorCode`, `OrderErrorCode` 등으로 분리하는 방향도 고려할 수 있습니다.